### PR TITLE
:art: feat(branding): update application logo and primary theme color…

### DIFF
--- a/resources/images/logo.svg
+++ b/resources/images/logo.svg
@@ -1,18 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="39" height="22" viewBox="0 0 39 22" fill="none">
-<rect width="7.37565" height="21.1131" rx="3.68783" transform="matrix(-0.865206 0.501417 0.498585 0.866841 27.425 0)" fill="currentColor"/>
-<rect width="7.37565" height="21.1131" rx="3.68783" transform="matrix(-0.865206 0.501417 0.498585 0.866841 27.5004 0)" fill="url(#paint0_linear_1041_5978)" fill-opacity="0.4"/>
-<rect width="7.37565" height="21.1131" rx="3.68783" transform="matrix(0.865206 0.501417 -0.498585 0.866841 24.6698 0)" fill="currentColor"/>
-<rect width="7.37565" height="21.1131" rx="3.68783" transform="matrix(-0.865206 0.501417 0.498585 0.866841 13.3428 0)" fill="currentColor"/>
-<rect width="7.37565" height="21.1131" rx="3.68783" transform="matrix(-0.865206 0.501417 0.498585 0.866841 13.3815 0)" fill="url(#paint1_linear_1041_5978)" fill-opacity="0.4"/>
-<rect width="7.37565" height="21.1131" rx="3.68783" transform="matrix(0.865206 0.501417 -0.498585 0.866841 10.5267 0)" fill="currentColor"/>
-<defs>
-<linearGradient id="paint0_linear_1041_5978" x1="3.68783" y1="0" x2="3.68783" y2="21.1131" gradientUnits="userSpaceOnUse">
-<stop/>
-<stop offset="1" stop-opacity="0"/>
-</linearGradient>
-<linearGradient id="paint1_linear_1041_5978" x1="3.68783" y1="0" x2="3.68783" y2="21.1131" gradientUnits="userSpaceOnUse">
-<stop/>
-<stop offset="1" stop-opacity="0"/>
-</linearGradient>
-</defs>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none">
+  <!-- Star symbol background -->
+  <circle cx="12" cy="12" r="10" fill="currentColor" opacity="0.1"/>
+  
+  <!-- Star icon -->
+  <path d="M12 5L14.73 14.27H24L17.14 19.73L19.73 29L12 23.54L4.27 29L6.86 19.73L0 14.27H9.27L12 5Z" fill="currentColor"/>
+  
+  <!-- Check mark -->
+  <g transform="translate(20, 8)">
+    <circle cx="8" cy="8" r="8" fill="currentColor" opacity="0.15"/>
+    <path d="M4 8L7 11L12 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+  
+  <!-- Text: SC (StarCheck initials) -->
+  <text x="24" y="42" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="currentColor" text-anchor="middle">SC</text>
 </svg>

--- a/resources/js/plugins/vuetify/theme.js
+++ b/resources/js/plugins/vuetify/theme.js
@@ -1,5 +1,5 @@
-export const staticPrimaryColor = '#666CFF'
-export const staticPrimaryDarkenColor = '#5C61E6'
+export const staticPrimaryColor = '#0066FF'
+export const staticPrimaryDarkenColor = '#0052CC'
 export const themes = {
   light: {
     dark: false,


### PR DESCRIPTION
… to blue

- Replaced logo with new StarCheck design combining star + check mark + SC initials
- Updated primary theme color from #666CFF to #0066FF (bright blue)
- Updated primary-darken color from #5C61E6 to #0052CC for hover/active states
- Logo now uses currentColor to adapt to theme changes
- Applied branding changes for improved visual identity